### PR TITLE
Include urls conversions and video_id extraction for embed urls

### DIFF
--- a/lib/youtube_addy.rb
+++ b/lib/youtube_addy.rb
@@ -2,6 +2,7 @@ class YouTubeAddy
   URL_Formats = {
       regular: /^(https?:\/\/)?(www\.)?youtube.com\/watch\?(.*\&)?v=([^&]+)/,
       shortened: /^(https?:\/\/)?(www\.)?youtu.be\/([^&]+)/,
+      embed: /^(https?:\/\/)?(www\.)?youtube.com\/embed\/([^&]+)/,
       invalid_chars: /[^a-zA-Z0-9\:\/\?\=\&\$\-\_\.\+\!\*\'\(\)\,]/
   }
 
@@ -16,6 +17,8 @@ class YouTubeAddy
       return match[4]
     elsif match = URL_Formats[:shortened].match(youtube_url)
       return match[3]
+    elsif match = URL_Formats[:embed].match(youtube_url)
+      return match[3]
     end
 
     nil
@@ -24,5 +27,15 @@ class YouTubeAddy
   def self.youtube_embed_url(youtube_url, width = 420, height = 315)
     vid_id = extract_video_id(youtube_url)
     %(<iframe width="#{width}" height="#{height}" src="http://www.youtube.com/embed/#{vid_id}" frameborder="0" allowfullscreen></iframe>)
+  end
+
+  def self.youtube_regular_url(youtube_url)
+    vid_id = extract_video_id(youtube_url)
+    "http://www.youtube.com/watch?v=#{ vid_id }"
+  end
+
+  def self.youtube_shortened_url(youtube_url)
+    vid_id = extract_video_id(youtube_url)
+    "http://youtu.be/#{ vid_id }"
   end
 end

--- a/lib/youtube_addy.rb
+++ b/lib/youtube_addy.rb
@@ -1,27 +1,23 @@
 class YouTubeAddy
-  URL_Formats = {
-      regular: /^(https?:\/\/)?(www\.)?youtube.com\/watch\?(.*\&)?v=([^&]+)/,
-      shortened: /^(https?:\/\/)?(www\.)?youtu.be\/([^&]+)/,
-      embed: /^(https?:\/\/)?(www\.)?youtube.com\/embed\/([^&]+)/,
-      invalid_chars: /[^a-zA-Z0-9\:\/\?\=\&\$\-\_\.\+\!\*\'\(\)\,]/
+  URL_FORMATS = {
+      regular: /^(https?:\/\/)?(www\.)?youtube.com\/watch\?(.*\&)?v=(?<id>[^&]+)/,
+      shortened: /^(https?:\/\/)?(www\.)?youtu.be\/(?<id>[^&]+)/,
+      embed: /^(https?:\/\/)?(www\.)?youtube.com\/embed\/(?<id>[^&]+)/
   }
 
+  INVALID_CHARS = /[^a-zA-Z0-9\:\/\?\=\&\$\-\_\.\+\!\*\'\(\)\,]/
+
   def self.has_invalid_chars?(youtube_url)
-    !URL_Formats[:invalid_chars].match(youtube_url).nil?
+    !INVALID_CHARS.match(youtube_url).nil?
   end
 
   def self.extract_video_id(youtube_url)
     return nil if has_invalid_chars?(youtube_url)
 
-    if match = URL_Formats[:regular].match(youtube_url)
-      return match[4]
-    elsif match = URL_Formats[:shortened].match(youtube_url)
-      return match[3]
-    elsif match = URL_Formats[:embed].match(youtube_url)
-      return match[3]
+    URL_FORMATS.values.each do |format_regex|
+      match = format_regex.match(youtube_url)
+      return match[:id] if match
     end
-
-    nil
   end
 
   def self.youtube_embed_url(youtube_url, width = 420, height = 315)

--- a/lib/youtube_addy.rb
+++ b/lib/youtube_addy.rb
@@ -2,7 +2,9 @@ class YouTubeAddy
   URL_FORMATS = {
       regular: /^(https?:\/\/)?(www\.)?youtube.com\/watch\?(.*\&)?v=(?<id>[^&]+)/,
       shortened: /^(https?:\/\/)?(www\.)?youtu.be\/(?<id>[^&]+)/,
-      embed: /^(https?:\/\/)?(www\.)?youtube.com\/embed\/(?<id>[^&]+)/
+      embed: /^(https?:\/\/)?(www\.)?youtube.com\/embed\/(?<id>[^&]+)/,
+      embed_as3: /^(https?:\/\/)?(www\.)?youtube.com\/v\/(?<id>[^?]+)/,
+      chromeless_as3: /^(https?:\/\/)?(www\.)?youtube.com\/apiplayer\?video_id=(?<id>[^&]+)/
   }
 
   INVALID_CHARS = /[^a-zA-Z0-9\:\/\?\=\&\$\-\_\.\+\!\*\'\(\)\,]/

--- a/test/test_youtube_addy.rb
+++ b/test/test_youtube_addy.rb
@@ -24,10 +24,10 @@ class TestYouTubeAddy < Test::Unit::TestCase
   end
 
   def test_youtube_urls_conversion
-    video_id      = "cD4TAgdS_Xw"
-    regular_url   = "http://www.youtube.com/watch?v=#{ video_id }"
-    embed_url     = "http://www.youtube.com/embed/#{ video_id }"
-    shortened_url = "http://youtu.be/#{ video_id }"
+    vid_id        = "cD4TAgdS_Xw"
+    regular_url   = "http://www.youtube.com/watch?v=#{ vid_id }"
+    embed_url     = "http://www.youtube.com/embed/#{ vid_id }"
+    shortened_url = "http://youtu.be/#{ vid_id }"
 
     assert_equal regular_url, YouTubeAddy.youtube_regular_url(embed_url)
     assert_equal regular_url, YouTubeAddy.youtube_regular_url(shortened_url)

--- a/test/test_youtube_addy.rb
+++ b/test/test_youtube_addy.rb
@@ -2,7 +2,6 @@ require "test/unit"
 require 'youtube_addy'
 
 class TestYouTubeAddy < Test::Unit::TestCase
-
   def test_invalid_youtube_url
     assert_equal nil, YouTubeAddy.extract_video_id("not a valid url")
     assert YouTubeAddy.has_invalid_chars?("http://www.youtube.com/watch?v=something<script>badthings</script>")
@@ -22,5 +21,18 @@ class TestYouTubeAddy < Test::Unit::TestCase
     assert_equal "cD4TAgdS_Xw", YouTubeAddy.extract_video_id("http://youtu.be/cD4TAgdS_Xw")
     assert_equal "cD4TAgdS_Xw", YouTubeAddy.extract_video_id("https://youtu.be/cD4TAgdS_Xw")
     assert_equal "cD4TAgdS_Xw", YouTubeAddy.extract_video_id("youtu.be/cD4TAgdS_Xw")
+  end
+
+  def test_youtube_urls_conversion
+    video_id      = "cD4TAgdS_Xw"
+    regular_url   = "http://www.youtube.com/watch?v=#{ video_id }"
+    embed_url     = "http://www.youtube.com/embed/#{ video_id }"
+    shortened_url = "http://youtu.be/#{ video_id }"
+
+    assert_equal regular_url, YouTubeAddy.youtube_regular_url(embed_url)
+    assert_equal regular_url, YouTubeAddy.youtube_regular_url(shortened_url)
+
+    assert_equal shortened_url, YouTubeAddy.youtube_shortened_url(embed_url)
+    assert_equal shortened_url, YouTubeAddy.youtube_shortened_url(regular_url)
   end
 end


### PR DESCRIPTION
- Include method to convert youtube url from any type for shortened and regular. 
- Include video_id extraction for embed urls.
- Remove magic number using named captures URL_FORMATS
- Split URL_FORMATS and INVALID_CHARS.
