### PR TITLE
Fix invalid urls for YouTubeAddy.extract_video_id

### DIFF
--- a/lib/youtube_addy.rb
+++ b/lib/youtube_addy.rb
@@ -16,10 +16,10 @@ class YouTubeAddy
   def self.extract_video_id(youtube_url)
     return nil if has_invalid_chars?(youtube_url)
 
-    URL_FORMATS.values.each do |format_regex|
+    URL_FORMATS.values.each_with_index do |format_regex, index|
       match = format_regex.match(youtube_url)
       return match[:id] if match
-      return nil if format_regex == URL_FORMATS.last
+      return nil if (index + 1)  == URL_FORMATS.count
     end
   end
 

--- a/lib/youtube_addy.rb
+++ b/lib/youtube_addy.rb
@@ -19,6 +19,7 @@ class YouTubeAddy
     URL_FORMATS.values.each do |format_regex|
       match = format_regex.match(youtube_url)
       return match[:id] if match
+      return nil if format_regex == URL_FORMATS.last
     end
   end
 


### PR DESCRIPTION
If never matches an URL_FORMAT it will return nil in the last item of the hash.
More details issue: https://github.com/datwright/youtube_addy/issues/2
