### PR TITLE
Provision to return only embed url for youtube

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,8 @@ YouTubeAddy.extract_video_id("http://youtube.com/watch?v=Cd4g33ijd<script>this_s
 YouTubeAddy.youtube_embed_url("http://youtu.be/cD4TAgdS_Xw",420,315)
 => '<iframe width="420" height="315" src="http://www.youtube.com/embed/cD4TAgdS_Xw" frameborder="0" allowfullscreen></iframe>'
 ```
+
+```ruby
+YouTubeAddy.youtube_embed_url_only("http://youtu.be/cD4TAgdS_Xw")
+=> 'http://www.youtube.com/embed/cD4TAgdS_Xw'
+```

--- a/lib/youtube_addy.rb
+++ b/lib/youtube_addy.rb
@@ -24,7 +24,7 @@ class YouTubeAddy
 
   def self.youtube_embed_url(youtube_url, width = 420, height = 315)
     vid_id = extract_video_id(youtube_url)
-    %(<iframe width="#{width}" height="#{height}" src="http://www.youtube.com/embed/#{vid_id}" frameborder="0" allowfullscreen></iframe>)
+    %(<iframe width="#{width}" height="#{height}" src="#{ youtube_embed_url_only(youtube_url) }" frameborder="0" allowfullscreen></iframe>)
   end
 
   def self.youtube_regular_url(youtube_url)
@@ -35,5 +35,10 @@ class YouTubeAddy
   def self.youtube_shortened_url(youtube_url)
     vid_id = extract_video_id(youtube_url)
     "http://youtu.be/#{ vid_id }"
+  end
+
+  def self.youtube_embed_url_only(youtube_url)
+    vid_id = extract_video_id(youtube_url)
+		"http://www.youtube.com/embed/#{ vid_id }"
   end
 end

--- a/lib/youtube_addy.rb
+++ b/lib/youtube_addy.rb
@@ -39,6 +39,6 @@ class YouTubeAddy
 
   def self.youtube_embed_url_only(youtube_url)
     vid_id = extract_video_id(youtube_url)
-		"http://www.youtube.com/embed/#{ vid_id }"
+	  "http://www.youtube.com/embed/#{ vid_id }"
   end
 end


### PR DESCRIPTION
I was using bootstrap three responsive snippets and there wasn't any function which returns only embed url for youtube. So I created one.
