### PR TITLE
Added optional parameter to allow all youtube urls to use HTTPSecure

### DIFF
--- a/lib/youtube_addy.rb
+++ b/lib/youtube_addy.rb
@@ -22,18 +22,18 @@ class YouTubeAddy
     end
   end
 
-  def self.youtube_embed_url(youtube_url, width = 420, height = 315)
+  def self.youtube_embed_url(youtube_url, width = 420, height = 315, options = {})
     vid_id = extract_video_id(youtube_url)
-    %(<iframe width="#{width}" height="#{height}" src="http://www.youtube.com/embed/#{vid_id}" frameborder="0" allowfullscreen></iframe>)
+    %(<iframe width="#{width}" height="#{height}" src="http#{'s' if options[:ssl]}://www.youtube.com/embed/#{vid_id}" frameborder="0" allowfullscreen></iframe>)
   end
 
-  def self.youtube_regular_url(youtube_url)
+  def self.youtube_regular_url(youtube_url, options = {})
     vid_id = extract_video_id(youtube_url)
-    "http://www.youtube.com/watch?v=#{ vid_id }"
+    "http#{'s' if options[:ssl]}://www.youtube.com/watch?v=#{ vid_id }"
   end
 
-  def self.youtube_shortened_url(youtube_url)
+  def self.youtube_shortened_url(youtube_url, options = {})
     vid_id = extract_video_id(youtube_url)
-    "http://youtu.be/#{ vid_id }"
+    "http#{'s' if options[:ssl]}://youtu.be/#{ vid_id }"
   end
 end

--- a/test/test_youtube_addy.rb
+++ b/test/test_youtube_addy.rb
@@ -24,15 +24,36 @@ class TestYouTubeAddy < Test::Unit::TestCase
   end
 
   def test_youtube_urls_conversion
-    vid_id        = "cD4TAgdS_Xw"
-    regular_url   = "http://www.youtube.com/watch?v=#{ vid_id }"
-    embed_url     = "http://www.youtube.com/embed/#{ vid_id }"
-    shortened_url = "http://youtu.be/#{ vid_id }"
+    vid_id              = "cD4TAgdS_Xw"
+    regular_url         = "http://www.youtube.com/watch?v=#{ vid_id }"
+    regular_url_https   = "https://www.youtube.com/watch?v=#{ vid_id }"
+    embed_url           = "http://www.youtube.com/embed/#{ vid_id }"
+    shortened_url       = "http://youtu.be/#{ vid_id }"
+    shortened_url_https = "https://youtu.be/#{ vid_id }"
 
     assert_equal regular_url, YouTubeAddy.youtube_regular_url(embed_url)
     assert_equal regular_url, YouTubeAddy.youtube_regular_url(shortened_url)
+    assert_equal regular_url_https, YouTubeAddy.youtube_regular_url(embed_url, :ssl => true)
+    assert_equal regular_url_https, YouTubeAddy.youtube_regular_url(shortened_url, :ssl => true)
 
     assert_equal shortened_url, YouTubeAddy.youtube_shortened_url(embed_url)
     assert_equal shortened_url, YouTubeAddy.youtube_shortened_url(regular_url)
+    assert_equal shortened_url_https, YouTubeAddy.youtube_shortened_url(embed_url, :ssl => true)
+    assert_equal shortened_url_https, YouTubeAddy.youtube_shortened_url(regular_url, :ssl => true)
+  end
+
+  def test_youtube_embed_url
+    vid_id                  = "cD4TAgdS_Xw"
+    regular_url             = "http://www.youtube.com/watch?v=#{ vid_id }"
+    iframe_default          = %(<iframe width="420" height="315" src="http://www.youtube.com/embed/#{vid_id}" frameborder="0" allowfullscreen></iframe>)
+    iframe_custom           = %(<iframe width="500" height="350" src="http://www.youtube.com/embed/#{vid_id}" frameborder="0" allowfullscreen></iframe>)
+    iframe_default_with_ssl = %(<iframe width="420" height="315" src="https://www.youtube.com/embed/#{vid_id}" frameborder="0" allowfullscreen></iframe>)
+    iframe_custom_with_ssl  = %(<iframe width="500" height="350" src="https://www.youtube.com/embed/#{vid_id}" frameborder="0" allowfullscreen></iframe>)
+
+    assert_equal iframe_default, YouTubeAddy.youtube_embed_url(regular_url)
+    assert_equal iframe_custom, YouTubeAddy.youtube_embed_url(regular_url, 500, 350)
+    assert_equal iframe_default_with_ssl, YouTubeAddy.youtube_embed_url(regular_url, 420, 315, :ssl => true)
+    assert_equal iframe_custom_with_ssl, YouTubeAddy.youtube_embed_url(regular_url, 500, 350, :ssl => true)
+
   end
 end


### PR DESCRIPTION
If your site uses embedded youtube players, and runs over HTTPS, iframes generated from youtube_addy wouldn't work, as they used HTTP.

This change is fully compatible with older versions of the gem, users should only have to update if they want to add HTTPS.
