### PR TITLE
Return nil if all attempts to match fail

### DIFF
--- a/lib/youtube_addy.rb
+++ b/lib/youtube_addy.rb
@@ -16,9 +16,14 @@ class YouTubeAddy
   def self.extract_video_id(youtube_url)
     return nil if has_invalid_chars?(youtube_url)
 
-    URL_FORMATS.values.each do |format_regex|
+    URL_FORMATS.values.inject(nil) do |result, format_regex|
       match = format_regex.match(youtube_url)
-      return match[:id] if match
+
+      if match
+        match[:id]
+      else
+        result
+      end
     end
   end
 

--- a/test/test_youtube_addy.rb
+++ b/test/test_youtube_addy.rb
@@ -4,6 +4,7 @@ require 'youtube_addy'
 class TestYouTubeAddy < Test::Unit::TestCase
   def test_invalid_youtube_url
     assert_equal nil, YouTubeAddy.extract_video_id("not a valid url")
+    assert_equal nil, YouTubeAddy.extract_video_id("example.com")
     assert YouTubeAddy.has_invalid_chars?("http://www.youtube.com/watch?v=something<script>badthings</script>")
     assert_equal nil, YouTubeAddy.extract_video_id("http://www.youtube.com/watch?v=something<script>badthings</script>")
   end


### PR DESCRIPTION
I ran into an issue today where if all matches failed you get returned the result of `[Array#each]` (i.e. the Array being enumerated). 

This seemed a bit counter intuitive given the docs seem to imply that `[YouTubeAddy.extract_video_id]` returns a nil when no ID can be extracted.

Thanks in advance for your time and for maintaining such a useful library.
